### PR TITLE
Fix typo in src/stories/Rating.stories.tsx

### DIFF
--- a/src/stories/Rating.stories.tsx
+++ b/src/stories/Rating.stories.tsx
@@ -80,7 +80,7 @@ WithTooltip.args = {
 export const CustomTooltip = Template.bind({})
 CustomTooltip.args = {
   showTooltip: true,
-  tooltipArray: ['Terrible', 'Bad', 'Average', 'Great', 'Prefect'],
+  tooltipArray: ['Terrible', 'Bad', 'Average', 'Great', 'Perfect'],
   onPointerEnter: undefined,
   onPointerLeave: undefined,
   onPointerMove: undefined


### PR DESCRIPTION
Fixes `Perfect` misspelt as `Prefect` (which actually has a different meaning)
https://github.com/micahlt/react-simple-star-rating/blob/fb69ff7a29dd7a59f96d04d7eeda93a663a98d80/src/stories/Rating.stories.tsx#L83